### PR TITLE
1: Add ability for a remote client to accept a session ID from a

### DIFF
--- a/hydra_client/config.py
+++ b/hydra_client/config.py
@@ -1,3 +1,6 @@
 port = 8080
 domain = '127.0.0.1'
 json_path = 'json'
+seed = 'changeme'
+cache_password = True
+cipherkey=b'M0EppyrL8yf9cTE7z5UywMBl1202aSTCntQ4ZFXLiiE='


### PR DESCRIPTION
differnt service (aka HWI) and to use that to log in to the API.
2: Add ability for a uuser's password to be saved in a file, but
avoiding storing it in plain text.

(cherry picked from commit 838f9656cf66ac7d175a88519e8f5ab3ef943f13)