### PR TITLE
Use sectionless config.get() arg format

### DIFF
--- a/hydra_client/click.py
+++ b/hydra_client/click.py
@@ -138,7 +138,7 @@ def plugin_to_xml(data):
 
 def write_plugins(plugins, app_name):
     """ Write the generated plugins to XML files. """
-    base_plugin_dir = Path(hydra_base.config.get('plugin', 'default_directory'))
+    base_plugin_dir = Path(hydra_base.config.get("plugin_default_directory"))
     base_plugin_dir = base_plugin_dir.joinpath(app_name)
 
     if not base_plugin_dir.exists():

--- a/hydra_client/connection/base_connection.py
+++ b/hydra_client/connection/base_connection.py
@@ -21,7 +21,7 @@ class BaseConnection(object):
     def __init__(self, *args, **kwargs):
         super(BaseConnection, self).__init__()
         self.app_name = kwargs.get('app_name', None)
-        self.dateformat = hydra_base.config.get('DEFAULT', 'datetime_format', DEFAULT_DATETIME_FORMAT)
+        self.dateformat = hydra_base.config.get("datetime_format", DEFAULT_DATETIME_FORMAT)
 
     def call(self, func_name, *args, **kwargs):
         """ Call a hydra-base function by name. """

--- a/hydra_client/output.py
+++ b/hydra_client/output.py
@@ -106,8 +106,7 @@ def validate_plugin_xml(plugin_xml_file_path):
         raise HydraPluginError("Couldn't find plugin.xml.")
 
     try:
-        plugin_xsd_path = os.path.expanduser(config.get('plugin',
-                                                        'plugin_xsd_path'))
+        plugin_xsd_path = os.path.expanduser(config.get("plugin_xsd_path"))
         log.info("Plugin Input xsd: %s", plugin_xsd_path)
         xmlschema_doc = etree.parse(plugin_xsd_path)
         xmlschema = etree.XMLSchema(xmlschema_doc)

--- a/hydra_client/templates.py
+++ b/hydra_client/templates.py
@@ -117,8 +117,7 @@ def xsd_validate(template_file):
     with open(template_file) as f:
         xml_template = f.read()
 
-    template_xsd_path = os.path.expanduser(config.get('templates',
-                                                      'template_xsd_path'))
+    template_xsd_path = os.path.expanduser(config.get("template_xsd_path"))
     log.info("Template xsd: %s", template_xsd_path)
     xmlschema_doc = etree.parse(template_xsd_path)
     xmlschema = etree.XMLSchema(xmlschema_doc)

--- a/tests/hydra_base_fixtures.py
+++ b/tests/hydra_base_fixtures.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 import datetime
 
 global user_id
-user_id = config.get('DEFAULT', 'root_user_id', 1)
+user_id = config.get("root_user_id", 1)
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #18 

Updates all calls to `hydra_base.config.get()` to use new sectionless arg format following https://github.com/hydraplatform/hydra-base/issues/157